### PR TITLE
Adding read-only to autolibs server

### DIFF
--- a/install_ruby_and_rvm/install_ruby.sh
+++ b/install_ruby_and_rvm/install_ruby.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-curl -L https://get.rvm.io | bash -s stable --ruby &&
+curl -L https://get.rvm.io | bash -s stable --ruby --autolibs=read-only &&
 source ~/.rvm/scripts/rvm &&
 rvm requirements &&
 rvm install 2.3.1 &&


### PR DESCRIPTION
This is necessary because the new version of RVM use superuser to install autolibs in the server, showing error for users no-root.